### PR TITLE
ci(github-actions): Update auto-assign workflow to skip bot-initiated PRs and improve assignee handling

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -9,15 +9,12 @@ on:
 
 jobs:
   auto-assign:
-    name: Auto Assign
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - if: ${{ toJSON(github.event.pull_request.assignees) == '[]' }}
-        run: gh pr edit "${NUMBER}" --add-assignee "${ASSIGNEE}"
         env:
           GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.pull_request.number }}
-          ASSIGNEE: ${{ github.event.pull_request.user.login }}
+        run: |
+          gh pr --repo ${{ github.repository }} edit ${{ github.event.pull_request.number }} --add-assignee "${{ github.event.pull_request.user.login }}"


### PR DESCRIPTION
<!-- markdownlint-disable MD004 MD041 -->

## Ticket / Issue Number

> **Note**
> *Please fill in the ticket or issue number.*
> > Example:
> >
> > #1

## What's changed

> **Note**
> *Please explain what changes this pull request will make.*
> > Example:
> >
> > - Added functionality to perform 'bar' on 'foo'.

## Check List

- [x] Assign labels
- [x] Assign reviewers
- [x] Assign assignees

## Remark

> **Note**
> *Please provide additional remarks if necessary.*

<!-- markdownlint-enable MD004 MD041 -->
